### PR TITLE
🩹 Correction Semester.ts

### DIFF
--- a/lib/util/Semester.ts
+++ b/lib/util/Semester.ts
@@ -24,7 +24,7 @@ export const Semester = {
  */
 export const getCurrentSemester = (): Semester => {
     const month = new Date().getMonth()
-    return month >= 9 ? Semester.S1 : Semester.S2
+    return month >= 8 ? Semester.S1 : Semester.S2
 }
 
 /**


### PR DESCRIPTION
L'indexage commence à 0 donc le mois numéro 9 est octobre, pas septembre.